### PR TITLE
add &str support

### DIFF
--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -519,10 +519,6 @@ fn translate_str(chars: &mut Vec<char>, s: &str) -> Option<Vec<u8>> {
     }).collect()
 }
 
-fn all_ascii(s: &str) -> bool {
-    s.bytes().fold(0, |a, b| a | b) & 0x80 != 0
-}
-
 /// Returns the Levenshtein distance, bounded by a cost threshold `k`, between two utf8 encoded strings, using
 /// SIMD acceleration.
 /// # Arguments
@@ -539,7 +535,7 @@ fn all_ascii(s: &str) -> bool {
 /// assert!(dist.unwrap() == 1);
 /// ```
 pub fn levenshtein_simd_k_str(a: &str, b: &str, k: u32) -> Option<u32> {
-    if all_ascii(a) && all_ascii(b) {
+    if a.is_ascii() && b.is_ascii() {
         levenshtein_simd_k(a.as_bytes(), b.as_bytes(), k)
     } else {
         let mut chars = Vec::with_capacity(256);

--- a/src/levenshtein.rs
+++ b/src/levenshtein.rs
@@ -88,8 +88,28 @@ pub const RDAMERAU_COSTS: EditCosts = EditCosts{mismatch_cost: 1, gap_cost: 1, s
 ///
 /// assert!(dist == 1);
 /// ```
-pub fn levenshtein_naive(a: &[u8], b: &[u8]) -> u32 {
+pub fn levenshtein_naive<T: PartialEq>(a: &[T], b: &[T]) -> u32 {
     levenshtein_naive_with_opts(a, b, false, LEVENSHTEIN_COSTS).0
+}
+
+/// Returns the Levenshtein distance between two strings using the naive scalar algorithm.
+///
+/// # Arguments
+/// * `a` - first string (&str)
+/// * `b` - second string (&str)
+///
+/// # Example
+/// ```
+/// # use triple_accel::*;
+/// # use triple_accel::levenshtein::*;
+/// let dist = levenstein_native_str("abc", "ab");
+///
+/// assert!(dist == 1);
+/// ```
+pub fn levenstein_native_str(a: &str, b: &str) -> u32 {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    levenshtein_naive(&a, &b)
 }
 
 /// Returns the Levenshtein distance between two strings and optionally, the edit traceback,
@@ -110,7 +130,10 @@ pub fn levenshtein_naive(a: &[u8], b: &[u8]) -> u32 {
 /// assert!(dist == (1, Some(vec![Edit{edit: EditType::Match, count: 2},
 ///                               Edit{edit: EditType::BGap, count: 1}])));
 /// ```
-pub fn levenshtein_naive_with_opts(a: &[u8], b: &[u8], trace_on: bool, costs: EditCosts) -> (u32, Option<Vec<Edit>>) {
+#[inline]
+pub fn levenshtein_naive_with_opts<T>(a: &[T], b: &[T], trace_on: bool, costs: EditCosts) -> (u32, Option<Vec<Edit>>)
+    where T: PartialEq
+{
     let swap = a.len() > b.len(); // swap so that a len <= b len
     let a_new = if swap {b} else {a};
     let a_new_len = a_new.len();
@@ -300,7 +323,10 @@ pub fn levenshtein_naive_k(a: &[u8], b: &[u8], k: u32) -> Option<u32> {
 /// assert!(dist.unwrap() == (1, Some(vec![Edit{edit: EditType::Match, count: 2},
 ///                                        Edit{edit: EditType::BGap, count: 1}])));
 /// ```
-pub fn levenshtein_naive_k_with_opts(a: &[u8], b: &[u8], k: u32, trace_on: bool, costs: EditCosts) -> Option<(u32, Option<Vec<Edit>>)> {
+#[inline]
+pub fn levenshtein_naive_k_with_opts<T>(a: &[T], b: &[T], k: u32, trace_on: bool, costs: EditCosts) -> Option<(u32, Option<Vec<Edit>>)>
+    where T: PartialEq
+{
     let swap = a.len() > b.len(); // swap so that a len <= b len
     let a_new = if swap {b} else {a};
     let a_new_len = a_new.len();


### PR DESCRIPTION
If am no totally wrong, `&str` can be supported quite easily.
As the algorithm only ever checks for equality, the input type can be any `T: PartialEq`.